### PR TITLE
fix: add missing provider option

### DIFF
--- a/src/lib/ngxs.setup.ts
+++ b/src/lib/ngxs.setup.ts
@@ -73,7 +73,8 @@ export class NgxsTestBed {
                 NgxsTestModule,
                 NgxsModule.forRoot(options.states || [], options.ngxsOptions || {}),
                 ...(options.imports || [])
-            ]
+            ],
+            providers: options.providers || []
         }).compileComponents();
 
         NgxsTestBed.ngxsBootstrap();

--- a/src/lib/symbol.ts
+++ b/src/lib/symbol.ts
@@ -1,5 +1,5 @@
 import { StateContext, Store } from '@ngxs/store';
-import { ModuleWithProviders, Type } from '@angular/core';
+import { ModuleWithProviders, Provider, Type } from '@angular/core';
 import { TestBedStatic } from '@angular/core/testing';
 import { NgxsConfig } from '@ngxs/store/src/symbols';
 import { Observable } from 'rxjs';
@@ -9,6 +9,7 @@ export interface NgxsOptionsTesting {
     ngxsOptions?: Partial<NgxsConfig>;
     imports?: ModuleWithProviders[];
     before?: () => void;
+    providers?: Provider[];
 }
 
 export interface StateContextMap {


### PR DESCRIPTION
Hi,
while testing the current implementation, I realised that if the state depends on any Service we can not easily provide the service or a mock.
So here is the PR 😉 